### PR TITLE
Fix Thracian culture group having same color as Dravidian

### DIFF
--- a/common/cultures/00_thracian.txt
+++ b/common/cultures/00_thracian.txt
@@ -1,5 +1,5 @@
 ﻿thrace_group = {
-	color = hsv { 0.8 0.6 0.6 }
+	color = hsv { 0.463 0.95 0.8 }
 	
 	primary = archers
 	second = heavy_infantry


### PR DESCRIPTION
Both groups had color `hsv { 0.8 0.6 0.6 }`
Related error line:
> [13:30:23][utility.h:231]: Culture group thrace_group has same color as indian

Old Thracian (same as Dravidian):
![image](https://user-images.githubusercontent.com/29546927/124268556-f2ea6b00-db39-11eb-95a8-831cc389e43d.png)

New Thracian:
![image](https://user-images.githubusercontent.com/29546927/124267765-fb8e7180-db38-11eb-8474-ddfa3991ee98.png)
