### PR TITLE
Scripted Triggers for Zorgoball formables

### DIFF
--- a/common/scripted_triggers/00_decisions_inv_1_0.txt
+++ b/common/scripted_triggers/00_decisions_inv_1_0.txt
@@ -29,6 +29,8 @@ is_tier_1_formable_trigger = {
 		tag = LIG #Liguria
 		tag = ALA #Alania
 		tag = PIY #Piaoyue
+		tag = CSC #Corsica
+		tag = HSD #Hellespontine District
 	}
 }
 
@@ -75,6 +77,7 @@ is_tier_2_formable_trigger = {
 		tag = DHE #Dahae
 		tag = NMT #Neo-Mitanni
 		tag = MSG #Massagetia
+		tag = GMA #Greater Maeotia
 	}
 }
 


### PR DESCRIPTION
Adds scripted triggers for Zorgoball's formables, otherwise forming one of the nations will escape from the tier system.