### PR TITLE
Fezzani culture group legion loc fix

### DIFF
--- a/localization/english/cultures_l_english.yml
+++ b/localization/english/cultures_l_english.yml
@@ -552,7 +552,7 @@
  ARMY_NAME_fezzani:0 "$NUM$$ORDER$ Army"
  NAVY_NAME_fezzani:0 "$NUM$$ORDER$ Navy"
  COHORT_NAME_fezzani:1 "$COHORT_NAME_north_african$"
- LEGION_NAME_fezzani:0 "$LEGION_NAME_north_african$"
+ # LEGION_NAME_fezzani:0 "$LEGION_NAME_north_african$" # LEGION_NAME_north_african is not localized in English
 
  #South Arabian
  ARMY_NAME_south_arabian:0 "$NUM$$ORDER$ Army"


### PR DESCRIPTION
The bug: https://discord.com/channels/839056459202953237/839056459773640729/1317631233970274304
![obraz](https://github.com/user-attachments/assets/b164547c-d625-42ab-acbe-2290b8562853)


After the fix: default loc is used.
![obraz](https://github.com/user-attachments/assets/dcbdac0b-582a-45c7-873b-b3294a775b9d)
